### PR TITLE
change Mkdir to MkdirAll, because os.Mkdir is used to create a single…

### DIFF
--- a/main.go
+++ b/main.go
@@ -294,7 +294,7 @@ func mkDirIfNotExist(dirName string) {
 	if _, err := os.Stat(dirName); err == nil {
 		return
 	}
-	if err := os.Mkdir(dirName, 0755); err != nil {
+	if err := os.MkdirAll(dirName, 0755); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
Поправил MkDir на MkdirAll

```
func MkdirAll(path string, perm FileMode) error

MkdirAll creates a directory named path, along with any necessary parents, and returns nil, or else returns an error. The permission bits perm are used for all directories that MkdirAll creates. If path is already a directory, MkdirAll does nothing and returns nil.
```